### PR TITLE
Remove setup-tools version constraint

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,12 +1,8 @@
 [buildout]
 parts = test
 develop = src
-versions = versions
 
 [test]
 recipe = pbp.recipe.noserunner
 eggs =
     hiptestpublishersamples
-
-[versions]
-setuptools = 33.1.1


### PR DESCRIPTION
Issue with latest buildout is leading to an upgrade/restart loop of setup-tools when a version is specified.